### PR TITLE
Changement des valeurs de fin pour les boucles des statistiques de vente

### DIFF
--- a/log1-chapitre-tableau.tex
+++ b/log1-chapitre-tableau.tex
@@ -374,7 +374,7 @@
 			\Empty
 		\EndWhile
 		\Empty
-		\For{i \K{de} 1 \K{à} 10}
+		\For{i \K{de} 1 \K{à} nbArticles}
 			\Write "quantité vendue de produit ", i, ": ", cpt[i]
 		\EndFor
 		\Empty
@@ -401,7 +401,7 @@
 	
 		\cadre{
 	\begin{pseudo}
-	\LComment Calcule et affiche la quantité vendue de 10 produits.
+	\LComment Calcule et affiche la quantité vendue de x produits.
 	\Module{statistiquesVentesAvecTableau}{}{}
 		\Empty
 		\Decl cpt~: \K{tableau} d’entiers
@@ -429,7 +429,7 @@
 			\Empty
 		\EndWhile
 		\Empty
-		\For{i \K{de} 1 \K{à} 10}
+		\For{i \K{de} 1 \K{à} nbArticles}
 			\Write "quantité vendue de produit ", i, ": ", cpt[i]
 		\EndFor
 		\Empty


### PR DESCRIPTION
Le commentaire ligne 350 semble sous-entendre qu’il faut afficher `x` valeurs, `nbArticles` plutôt que 10 dans le cas de l’algorithme.
2e commentaire et algorithme modifiés pour garder la cohérence entre les deux.
(signalé par Hakim)
