### PR TITLE
Correction typo

### DIFF
--- a/log1-chapitre-tri.tex
+++ b/log1-chapitre-tri.tex
@@ -568,7 +568,7 @@
 
 	\cadre{
 	\begin{pseudo}
-		\LComment Retourne de l’indice du minimum entre les indices début et fin du tableau reçu.
+		\LComment Retourne l’indice du minimum entre les indices début et fin du tableau reçu.
 		\Module{positionMin}{tab\In~: tableau[1 à n] d’entiers, début, fin~: entiers}{entier}
 			\Decl indiceMin, i~: entiers
 			\Let indiceMin \Gets début


### PR DESCRIPTION
s/Retourne de l’indice du minimum/Retourne l’indice du minimum/
